### PR TITLE
Try to use local `flow` when no `flow` found globally.

### DIFF
--- a/pythonx/cm_sources/flow.py
+++ b/pythonx/cm_sources/flow.py
@@ -21,7 +21,7 @@ import json
 import subprocess
 import os
 from os import path
-from sys import stdout
+from sys import stdout, platform
 
 logger = getLogger(__name__)
 
@@ -35,6 +35,13 @@ class Source(Base):
         from distutils.spawn import find_executable
         if not find_executable(self.flowpath):
             self.message('error', 'Can not find [%s] binary. Please check your installation or g:flow#flowpath' % self.flowpath)
+            localflow = path.join(nvim.eval('getcwd()'), 'node_modules', 'flow-bin')
+            osname = { 'win32': 'win64', 'darwin': 'osx', 'linux': 'linux' }[platform]
+            version = [v for v in os.listdir(localflow) if osname in v][0]
+            localflow = path.join(localflow, version, 'flow')
+            if find_executable(localflow):
+                self.message('message', "Local flow being used: [%s]" % localflow)
+                self.flowpath = localflow
 
     def cm_refresh(self, info, ctx, *args):
 

--- a/pythonx/cm_sources/flow.py
+++ b/pythonx/cm_sources/flow.py
@@ -31,17 +31,18 @@ class Source(Base):
         super(Source, self).__init__(nvim)
 
         self.flowpath = nvim.eval('get(g:, "flow#flowpath", "flow")')
-
         from distutils.spawn import find_executable
-        if not find_executable(self.flowpath):
-            self.message('error', 'Can not find [%s] binary. Please check your installation or g:flow#flowpath' % self.flowpath)
-            localflow = path.join(nvim.eval('getcwd()'), 'node_modules', 'flow-bin')
-            osname = { 'win32': 'win64', 'darwin': 'osx', 'linux': 'linux' }[platform]
-            version = [v for v in os.listdir(localflow) if osname in v][0]
-            localflow = path.join(localflow, version, 'flow')
-            if find_executable(localflow):
-                self.message('message', "Local flow being used: [%s]" % localflow)
-                self.flowpath = localflow
+        localflow = path.join(nvim.eval('getcwd()'), 'node_modules', 'flow-bin')
+        osname = { 'win32': 'win64', 'darwin': 'osx', 'linux': 'linux' }[platform]
+        version = [v for v in os.listdir(localflow) if osname in v][0]
+        localflow = path.join(localflow, version, 'flow')
+
+        if find_executable(localflow):
+            self.flowpath = localflow
+        elif find_executable(self.flowpath):
+            self.message('message', "No local flow, falling back to globally defined flow: [%s]" % self.flowpath)
+        else:
+            self.message('error', "No flow binary found locally or globally. Please check your setup.")
 
     def cm_refresh(self, info, ctx, *args):
 


### PR DESCRIPTION
Try to use the local `flow` binary in `node_modules/` when failing to find the `flow` set in `g:flow#flowpath` or `flow` in the `PATH`.

Motivated to do this when trying to use a global `flow` binary with locally installed `eslint` that calling local `flow` to do typecheck, which results in failure of starting the `flow` server for autocompletion.

Tested on my Windows 10 and Archlinux in VM. Should work on OSX (theoretically, no machine to test though)