### PR TITLE
Fixed problem that prevented global flow from working

### DIFF
--- a/pythonx/cm_sources/flow.py
+++ b/pythonx/cm_sources/flow.py
@@ -33,12 +33,9 @@ class Source(Base):
         self.flowpath = nvim.eval('get(g:, "flow#flowpath", "flow")')
         from distutils.spawn import find_executable
 
-        localflow = path.join(nvim.eval('getcwd()'), 'node_modules', 'flow-bin')
+        localflow = path.join(nvim.eval('getcwd()'), 'node_modules', '.bin', 'flow')
 
         if find_executable(localflow):
-            osname = { 'win32': 'win64', 'darwin': 'osx', 'linux': 'linux' }[platform]
-            version = [v for v in os.listdir(localflow) if osname in v][0]
-            localflow = path.join(localflow, version, 'flow')
             self.flowpath = localflow
         elif find_executable(self.flowpath):
             self.message('message', "No local flow, falling back to globally defined flow: [%s]" % self.flowpath)

--- a/pythonx/cm_sources/flow.py
+++ b/pythonx/cm_sources/flow.py
@@ -32,12 +32,13 @@ class Source(Base):
 
         self.flowpath = nvim.eval('get(g:, "flow#flowpath", "flow")')
         from distutils.spawn import find_executable
+
         localflow = path.join(nvim.eval('getcwd()'), 'node_modules', 'flow-bin')
-        osname = { 'win32': 'win64', 'darwin': 'osx', 'linux': 'linux' }[platform]
-        version = [v for v in os.listdir(localflow) if osname in v][0]
-        localflow = path.join(localflow, version, 'flow')
 
         if find_executable(localflow):
+            osname = { 'win32': 'win64', 'darwin': 'osx', 'linux': 'linux' }[platform]
+            version = [v for v in os.listdir(localflow) if osname in v][0]
+            localflow = path.join(localflow, version, 'flow')
             self.flowpath = localflow
         elif find_executable(self.flowpath):
             self.message('message', "No local flow, falling back to globally defined flow: [%s]" % self.flowpath)


### PR DESCRIPTION
The problem seems to be that if the path `./node_modules/flow-bin` is missing then `os.listdir` fails. Without this fix globally installed flow wont work (atleast not on my setup).